### PR TITLE
Make sure the service name is the same everywhere

### DIFF
--- a/cloudformation/template.yml
+++ b/cloudformation/template.yml
@@ -41,7 +41,7 @@ Resources:
           Value: ${self:provider.environment.STAGE}
       EvaluationPeriods: 1
       MetricName: BuyPrice
-      Namespace: Coinboss
+      Namespace: ${self:service}
       Period: 60
       Statistic: Average
       Threshold: ${self:provider.environment.LOW_BUY_PRICE_THRESHOLD}
@@ -63,7 +63,7 @@ Resources:
           Value: ${self:provider.environment.STAGE}
       EvaluationPeriods: 1
       MetricName: BuyPrice
-      Namespace: Coinboss
+      Namespace: ${self:service}
       Period: 300
       Statistic: Average
       Threshold: ${self:provider.environment.HIGH_BUY_PRICE_THRESHOLD}
@@ -85,7 +85,7 @@ Resources:
           Value: ${self:provider.environment.STAGE}
       EvaluationPeriods: 1
       MetricName: SellPrice
-      Namespace: Coinboss
+      Namespace: ${self:service}
       Period: 300
       Statistic: Average
       Threshold: ${self:provider.environment.LOW_SELL_PRICE_THRESHOLD}
@@ -107,7 +107,7 @@ Resources:
           Value: ${self:provider.environment.STAGE}
       EvaluationPeriods: 1
       MetricName: SellPrice
-      Namespace: Coinboss
+      Namespace: ${self:service}
       Period: 60
       Statistic: Average
       Threshold: ${self:provider.environment.HIGH_SELL_PRICE_THRESHOLD}

--- a/lib/cloudWatch.js
+++ b/lib/cloudWatch.js
@@ -20,7 +20,7 @@ export default class CloudWatch {
 
   constructor() {
     this.cloudwatch = new AWS.CloudWatch({ region: process.env.REGION || 'eu-central-1' });
-    this.namespace = 'Coinboss';
+    this.namespace = process.env.SERVICE_NAME;
   }
 
   putPriceMetric(args) {

--- a/lib/cloudWatch.js
+++ b/lib/cloudWatch.js
@@ -20,7 +20,7 @@ export default class CloudWatch {
 
   constructor() {
     this.cloudwatch = new AWS.CloudWatch({ region: process.env.REGION || 'eu-central-1' });
-    this.namespace = process.env.SERVICE_NAME;
+    this.namespace = process.env.SERVICE_NAME || 'coinboss';
   }
 
   putPriceMetric(args) {


### PR DESCRIPTION
The naming convention differs. Sometimes with capital, sometimes without. It's better to have them consistent, as this makes things more predictable.

Merging this PR will make everything use the central service designator, which will always be consistent.